### PR TITLE
Enhance pipeline with more options for environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ coverage
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Jetbrains
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+0.9.2 (mowies)
+--------------
+1. Add option to set pipeline and project scoped environment variables.
+
+
 0.9.1 (ksindi)
 --------------
 

--- a/README.md
+++ b/README.md
@@ -15,19 +15,23 @@ Example
 steps:
   - label: ":buildkite:"
     plugins:
-      - jwplayer/buildpipe#v0.9.1:
+      - jwplayer/buildpipe#v0.9.2:
           dynamic_pipeline: dynamic_pipeline.yml
 ```
 
 ### dynamic\_pipeline.yml
 
 ```yaml
+env:
+  GLOBAL_ENV_VAR: test
 projects:
  - label: project1
    path: project1/  # changes in this directory will trigger steps for project1
    skip:
      - deploy*  # skip steps with label matching deploy* (e.g. deploy-prd)
      - test
+   env:
+     PROJECT_ENV_VAR: project1variable
  - label: project2
    skip: test
    path:
@@ -94,6 +98,10 @@ The above pipelines specify the following:
 -   The env variable `BUILDPIPE_PROJECT_PATH` is created by buildpipe as
     the project\'s path. If multiple paths are specified for a project,
     it\'s the first path.
+-   There is a global environment variable defined (`GLOBAL_ENV_VAR`).
+    This variable will be added to every step in the pipeline.
+-   There is also a project scoped environment variable defined (`PROJECT_ENV_VAR`).
+    That variable will be added to all steps of the project where it was defined (`project1`).
 
 ### Full working example
 
@@ -114,19 +122,44 @@ Configuration
 
 ### Project schema
 
-| Option | Required | Type   | Default | Description                           | Environment variable |
-| ------ | -------- | ------ | ------- | ------------------------------------- | -------------------- |
-| label  | Yes      | string |         | Project label                         | `BUILDPIPE_PROJECT_LABEL` |
-| path   | Yes      | array  |         | The path(s) that specify changes to a project | `BUILDPIPE_PROJECT_PATH` |
-| skip   | No       | array  |         | Exclude steps that have labels that match the rule |         |
+| Option | Required | Type        | Default | Description                           | Environment variable |
+| ------ | -------- | ----------- | ------- | ------------------------------------- | -------------------- |
+| label  | Yes      | string      |         | Project label                         | `BUILDPIPE_PROJECT_LABEL` |
+| path   | Yes      | array       |         | The path(s) that specify changes to a project | `BUILDPIPE_PROJECT_PATH` |
+| skip   | No       | array       |         | Exclude steps that have labels that match the rule |         |
+| env    | No       | dictionary  |         | Define environment variable on a project scope |         |
 
 Other useful things to note:
 
--   Option `skip` make use of Unix shell-style wildcards (Look at
+-   Option `skip` makes use of Unix shell-style wildcards (Look at
     .gitignore files for inspiration)
 -   If multiple paths are specified, the environment variable
     `BUILDPIPE_PROJECT_PATH` will be the first path.
 -   Environment variables are available in the pipeline step.
+
+### Environment Variables
+
+Since version 0.9.2, there is the option to define environment variables on different scope levels in the pipeline.
+Buildkite already supports environment variables defined on a step scope, but buildpipe adds the ability to define global
+and also project specific environment variables.
+
+#### Project env vars
+```yaml
+env:
+  THIS_IS_A_GLOBAL_ENV_VAR: global
+  GLOBAL_ENV_VAR_2: another_global_value
+projects:
+  - label: project1
+    path: project1/
+    env:
+      THIS_IS_A_PROJECT_ENV_VAR: project_scoped
+      PROJECT_ENV_VAR_2: second_env_var_value
+  - label: project2
+    ...
+steps:
+  - label: step1
+    ...
+```
 
 `diff_` commands
 ----------------

--- a/hooks/command
+++ b/hooks/command
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-buildpipe_version="${BUILDKITE_PLUGIN_BUILDPIPE_VERSION:-0.9.1}"
+buildpipe_version="${BUILDKITE_PLUGIN_BUILDPIPE_VERSION:-0.9.2}"
 is_test="${BUILDKITE_PLUGIN_BUILDPIPE_TEST_MODE:-false}"
 
 if [[ "$is_test" == "false" ]]; then

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ const pluginPrefix = "BUILDKITE_PLUGIN_BUILDPIPE_"
 type Config struct {
 	Projects []Project     `yaml:"projects"`
 	Steps    []interface{} `yaml:"steps"`
-	Env      []interface{} `yaml:"env"`
+	Env      map[string]string `yaml:"env"`
 }
 
 func NewConfig(filename string) *Config {

--- a/main.go
+++ b/main.go
@@ -11,8 +11,8 @@ import (
 const pluginPrefix = "BUILDKITE_PLUGIN_BUILDPIPE_"
 
 type Config struct {
-	Projects []Project     `yaml:"projects"`
-	Steps    []interface{} `yaml:"steps"`
+	Projects []Project         `yaml:"projects"`
+	Steps    []interface{}     `yaml:"steps"`
 	Env      map[string]string `yaml:"env"`
 }
 

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	pipeline := generatePipeline(config.Steps, affectedProjects)
+	pipeline := generatePipeline(config.Steps, config.Env, affectedProjects)
 
 	uploadPipeline(*pipeline)
 }

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ const pluginPrefix = "BUILDKITE_PLUGIN_BUILDPIPE_"
 type Config struct {
 	Projects []Project     `yaml:"projects"`
 	Steps    []interface{} `yaml:"steps"`
+	Env      []interface{} `yaml:"env:"`
 }
 
 func NewConfig(filename string) *Config {

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ const pluginPrefix = "BUILDKITE_PLUGIN_BUILDPIPE_"
 type Config struct {
 	Projects []Project     `yaml:"projects"`
 	Steps    []interface{} `yaml:"steps"`
-	Env      []interface{} `yaml:"env:"`
+	Env      []interface{} `yaml:"env"`
 }
 
 func NewConfig(filename string) *Config {

--- a/pipeline.go
+++ b/pipeline.go
@@ -12,7 +12,6 @@ import (
 
 type Pipeline struct {
 	Steps []interface{}     `yaml:"steps"`
-	Env   map[string]string `yaml:"env"`
 }
 
 func generateProjectSteps(step interface{}, projects []Project) []interface{} {
@@ -48,14 +47,18 @@ func generatePipeline(steps []interface{}, pipelineEnv map[string]string, projec
 			continue
 		}
 
-		env, ok := stepMap["env"].(map[interface{}]interface{})
-		if !ok {
-			env = make(map[interface{}]interface{})
-			stepMap["env"] = env
-		}
+		env, foundEnv := stepMap["env"].(map[interface{}]interface{})
+		_, foundBlockStep := stepMap["block"].(string)
 
-		for envVarName, envVarValue := range pipelineEnv {
-			env[envVarName] = envVarValue
+		if !foundBlockStep {
+			if !foundEnv {
+				env = make(map[interface{}]interface{})
+				stepMap["env"] = env
+			}
+
+			for envVarName, envVarValue := range pipelineEnv {
+				env[envVarName] = envVarValue
+			}
 		}
 
 		value, ok := env["BUILDPIPE_SCOPE"]

--- a/pipeline.go
+++ b/pipeline.go
@@ -63,9 +63,21 @@ func generatePipeline(steps []interface{}, pipelineEnv []interface{}, projects [
 		}
 	}
 
+	generatedSteps = addPipelineEnv(generatedSteps, pipelineEnv)
+
 	return &Pipeline{
 		Steps: generatedSteps,
 	}
+}
+
+func addPipelineEnv(steps []interface{}, pipelineEnv []interface{}) []interface{} {
+	for envName, envValue := range pipelineEnv {
+		for step := range steps {
+			step.env[envName] = envValue
+		}
+	}
+
+	return steps
 }
 
 func uploadPipeline(pipeline Pipeline) {

--- a/pipeline.go
+++ b/pipeline.go
@@ -12,6 +12,7 @@ import (
 
 type Pipeline struct {
 	Steps []interface{} `yaml:"steps"`
+	Env map[string]string `yaml:"env"`
 }
 
 func generateProjectSteps(step interface{}, projects []Project) []interface{} {
@@ -37,7 +38,7 @@ func generateProjectSteps(step interface{}, projects []Project) []interface{} {
 	return projectSteps
 }
 
-func generatePipeline(steps []interface{}, projects []Project) *Pipeline {
+func generatePipeline(steps []interface{}, pipelineEnv []interface{}, projects []Project) *Pipeline {
 	generatedSteps := make([]interface{}, 0)
 
 	for _, step := range steps {

--- a/pipeline.go
+++ b/pipeline.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Pipeline struct {
-	Steps []interface{} `yaml:"steps"`
+	Steps []interface{}   `yaml:"steps"`
 	Env map[string]string `yaml:"env"`
 }
 

--- a/pipeline.go
+++ b/pipeline.go
@@ -11,8 +11,8 @@ import (
 )
 
 type Pipeline struct {
-	Steps []interface{}   `yaml:"steps"`
-	Env map[string]string `yaml:"env"`
+	Steps []interface{}     `yaml:"steps"`
+	Env   map[string]string `yaml:"env"`
 }
 
 func generateProjectSteps(step interface{}, projects []Project) []interface{} {
@@ -50,12 +50,12 @@ func generatePipeline(steps []interface{}, pipelineEnv map[string]string, projec
 
 		env, ok := stepMap["env"].(map[interface{}]interface{})
 		if !ok {
-			generatedSteps = append(generatedSteps, step)
-			continue
+			env = make(map[interface{}]interface{})
+			stepMap["env"] = env
 		}
 
-		for envName, envVal := range pipelineEnv {
-			env[envName] = envVal
+		for envVarName, envVarValue := range pipelineEnv {
+			env[envVarName] = envVarValue
 		}
 
 		value, ok := env["BUILDPIPE_SCOPE"]

--- a/pipeline.go
+++ b/pipeline.go
@@ -26,6 +26,10 @@ func generateProjectSteps(step interface{}, projects []Project) []interface{} {
 			env["BUILDPIPE_PROJECT_LABEL"] = project.Label
 			env["BUILDPIPE_PROJECT_PATH"] = project.getMainPath()
 
+			for envVarName, envVarValue := range project.Env {
+				env[envVarName] = envVarValue
+			}
+
 			projectSteps = append(projectSteps, stepCopy)
 		}
 	}

--- a/pipeline.go
+++ b/pipeline.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Pipeline struct {
-	Steps []interface{}     `yaml:"steps"`
+	Steps []interface{} `yaml:"steps"`
 }
 
 func generateProjectSteps(step interface{}, projects []Project) []interface{} {

--- a/pipeline.go
+++ b/pipeline.go
@@ -38,7 +38,7 @@ func generateProjectSteps(step interface{}, projects []Project) []interface{} {
 	return projectSteps
 }
 
-func generatePipeline(steps []interface{}, pipelineEnv []interface{}, projects []Project) *Pipeline {
+func generatePipeline(steps []interface{}, pipelineEnv map[string]string, projects []Project) *Pipeline {
 	generatedSteps := make([]interface{}, 0)
 
 	for _, step := range steps {
@@ -54,6 +54,10 @@ func generatePipeline(steps []interface{}, pipelineEnv []interface{}, projects [
 			continue
 		}
 
+		for envName, envVal := range pipelineEnv {
+			env[envName] = envVal
+		}
+
 		value, ok := env["BUILDPIPE_SCOPE"]
 		if ok && value == "project" {
 			projectSteps := generateProjectSteps(step, projects)
@@ -63,21 +67,9 @@ func generatePipeline(steps []interface{}, pipelineEnv []interface{}, projects [
 		}
 	}
 
-	generatedSteps = addPipelineEnv(generatedSteps, pipelineEnv)
-
 	return &Pipeline{
 		Steps: generatedSteps,
 	}
-}
-
-func addPipelineEnv(steps []interface{}, pipelineEnv []interface{}) []interface{} {
-	for envName, envValue := range pipelineEnv {
-		for step := range steps {
-			step.env[envName] = envValue
-		}
-	}
-
-	return steps
 }
 
 func uploadPipeline(pipeline Pipeline) {

--- a/project.go
+++ b/project.go
@@ -37,6 +37,7 @@ type Project struct {
 	Label string
 	Path  StringArray
 	Skip  StringArray
+	Env   map[string]string
 }
 
 func (p *Project) getMainPath() string {

--- a/tests/dynamic_pipeline.yml
+++ b/tests/dynamic_pipeline.yml
@@ -28,7 +28,7 @@ steps: # the same schema as regular buildkite pipeline steps
     branches: "master"
     env:
       BUILDPIPE_SCOPE: project
-      TEST_ENV_STEP: test-step1
+      TEST_ENV_STEP: test-step
     command:
       - cd $$BUILDPIPE_PROJECT_PATH
       - make build

--- a/tests/dynamic_pipeline.yml
+++ b/tests/dynamic_pipeline.yml
@@ -1,11 +1,11 @@
 env:
-  - TEST_ENV_PIPELINE: test-pipeline
+  TEST_ENV_PIPELINE: test-pipeline
 projects:
  - label: project1
    path: project1/  # changes in this dir will trigger steps for project1
    skip: deploy*  # skip steps with label matching deploy* (e.g. deploy-prd)
    env:
-     - TEST_ENV_PROJECT: test-project
+     TEST_ENV_PROJECT: test-project
  - label: project2
    skip: test
    path:

--- a/tests/dynamic_pipeline.yml
+++ b/tests/dynamic_pipeline.yml
@@ -1,7 +1,11 @@
+env:
+  - TEST_ENV_PIPELINE: test-pipeline
 projects:
  - label: project1
    path: project1/  # changes in this dir will trigger steps for project1
    skip: deploy*  # skip steps with label matching deploy* (e.g. deploy-prd)
+   env:
+     - TEST_ENV_PROJECT: test-project
  - label: project2
    skip: test
    path:

--- a/tests/dynamic_pipeline.yml
+++ b/tests/dynamic_pipeline.yml
@@ -28,6 +28,7 @@ steps:  # the same schema as regular buildkite pipeline steps
     branches: "master"
     env:
       BUILDPIPE_SCOPE: project
+      TEST_ENV_STEP: test-step
     command:
       - cd $$BUILDPIPE_PROJECT_PATH
       - make build

--- a/tests/dynamic_pipeline.yml
+++ b/tests/dynamic_pipeline.yml
@@ -1,34 +1,34 @@
 env:
   TEST_ENV_PIPELINE: test-pipeline
 projects:
- - label: project1
-   path: project1/  # changes in this dir will trigger steps for project1
-   skip: deploy*  # skip steps with label matching deploy* (e.g. deploy-prd)
-   env:
-     TEST_ENV_PROJECT: test-project
- - label: project2
-   skip: test
-   path:
+  - label: project1
+    path: project1/ # changes in this dir will trigger steps for project1
+    skip: deploy* # skip steps with label matching deploy* (e.g. deploy-prd)
+    env:
+      TEST_ENV_PROJECT: test-project
+  - label: project2
+    skip: test
+    path:
       - project2/
-      - project1  # you can trigger a project using multiple paths
- - label: project3
-   skip:  # you can skip a list of projects
-     - test
-     - deploy-stg
-   path: project3/somedir/  # subpaths can also be triggered
-steps:  # the same schema as regular buildkite pipeline steps
+      - project1 # you can trigger a project using multiple paths
+  - label: project3
+    skip: # you can skip a list of projects
+      - test
+      - deploy-stg
+    path: project3/somedir/ # subpaths can also be triggered
+steps: # the same schema as regular buildkite pipeline steps
   - label: test
     env:
-      BUILDPIPE_SCOPE: project  # this variable ensures a test step is generated for each project
+      BUILDPIPE_SCOPE: project # this variable ensures a test step is generated for each project
     command:
-      - cd $$BUILDPIPE_PROJECT_PATH  # BUILDPIPE_PROJECT_PATH will be set by buildpipe
+      - cd $$BUILDPIPE_PROJECT_PATH # BUILDPIPE_PROJECT_PATH will be set by buildpipe
       - make test
   - wait
   - label: build
     branches: "master"
     env:
       BUILDPIPE_SCOPE: project
-      TEST_ENV_STEP: test-step
+      TEST_ENV_STEP: test-step1
     command:
       - cd $$BUILDPIPE_PROJECT_PATH
       - make build

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -43,6 +43,8 @@ steps:
     BUILDPIPE_PROJECT_LABEL: project1
     BUILDPIPE_PROJECT_PATH: project1/
     BUILDPIPE_SCOPE: project
+    TEST_ENV_PIPELINE: test-pipeline
+    TEST_ENV_PROJECT: test-project
   label: test project1
 - wait
 - agents:
@@ -56,6 +58,9 @@ steps:
     BUILDPIPE_PROJECT_LABEL: project1
     BUILDPIPE_PROJECT_PATH: project1/
     BUILDPIPE_SCOPE: project
+    TEST_ENV_PIPELINE: test-pipeline
+    TEST_ENV_PROJECT: test-project
+    TEST_ENV_STEP: test-step
   label: build project1
 - agents:
   - queue=build
@@ -68,6 +73,8 @@ steps:
     BUILDPIPE_PROJECT_LABEL: project2
     BUILDPIPE_PROJECT_PATH: project2/
     BUILDPIPE_SCOPE: project
+    TEST_ENV_PIPELINE: test-pipeline
+    TEST_ENV_STEP: test-step
   label: build project2
 - wait
 - branches: master
@@ -85,6 +92,7 @@ steps:
     BUILDPIPE_PROJECT_LABEL: project2
     BUILDPIPE_PROJECT_PATH: project2/
     BUILDPIPE_SCOPE: project
+    TEST_ENV_PIPELINE: test-pipeline
   label: deploy-stg project2
 - wait
 - block: ':rocket: Release!'
@@ -100,6 +108,7 @@ steps:
     BUILDPIPE_PROJECT_LABEL: project2
     BUILDPIPE_PROJECT_PATH: project2/
     BUILDPIPE_SCOPE: project
+    TEST_ENV_PIPELINE: test-pipeline
   label: deploy-prd project2
 EOM
 }

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -31,10 +31,8 @@ teardown() {
   refute_output --partial "label: test project2"
   refute_output --partial "label: test project3"
   IFS=''
-  while read line
-  do
-    assert_line "$line"
-  done << EOM
+
+  assert_output --partial << EOM
 steps:
 - command:
   - cd \$\$BUILDPIPE_PROJECT_PATH
@@ -80,6 +78,8 @@ steps:
 - branches: master
   command:
   - make tag-release
+  env:
+    TEST_ENV_PIPELINE: test-pipeline
   label: tag
 - wait
 - branches: master


### PR DESCRIPTION
### This PR
- adds the `env:` key in the pipeline definition to set global env vars that are added to every step
- adds the possibility to add project-wide env vars that are added to all steps of a project
- makes the unit testing more reliable (`assert_line` checks if the line is *anywhere* in the output but does not check where exactly or how often)

This PR fixes #71 