### PR TITLE
Support global/project/step env even if buildkite trigger step is used

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -104,8 +104,28 @@ func generatePipeline(steps []interface{}, pipelineEnv map[string]string, projec
 
 		env, foundEnv := stepMap["env"].(map[interface{}]interface{})
 		_, foundBlockStep := stepMap["block"].(string)
+		_, foundTriggerStep := stepMap["trigger"].(string)
 
-		if !foundBlockStep {
+		if foundTriggerStep {
+			// Is there a build property
+			build, foundBuild := stepMap["build"].(map[interface{}]interface{})
+
+			if (!foundBuild) {
+				build = make(map[interface{}]interface{}) // TODO allow nesting
+				stepMap["build"] = build
+			}
+
+			buildEnv, foundBuildEnv := build["env"].(map[interface{}]interface{})
+
+			if (!foundBuildEnv) {
+				buildEnv = make(map[interface{}]interface{})
+				build["env"] = buildEnv // env TODO add to build
+			}
+
+			for envVarName, envVarValue := range pipelineEnv {
+				buildEnv[envVarName] = envVarValue
+			}
+		} else if !foundBlockStep {
 			if !foundEnv {
 				env = make(map[interface{}]interface{})
 				stepMap["env"] = env

--- a/tests/dynamic_pipeline.yml
+++ b/tests/dynamic_pipeline.yml
@@ -21,6 +21,26 @@ steps: # the same schema as regular buildkite pipeline steps
     key: bootstrap
     command:
       - make bootstrap
+  - trigger: my-other-build-pipeline
+    label: trigger-another-pipeline # a non project scoped step (to test depends_on handling)
+    key: trigger-step
+    command:
+      - make trigger-step
+  - trigger: my-other-build-pipeline
+    label: trigger-another-pipeline # a non project scoped step (to test depends_on handling)
+    key: trigger-step
+    build:
+      env:
+        EXISTING_ENV_VAR: persisted
+    command:
+      - make trigger-step
+  - trigger: my-other-build-pipeline
+    label: trigger-another-pipeline # a non project scoped step (to test depends_on handling)
+    key: trigger-step
+    build:
+      message: 'has existing build key'
+    command:
+      - make trigger-step
   - label: test
     key: test
     env:

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -40,6 +40,32 @@ steps:
     TEST_ENV_PIPELINE: test-pipeline
   key: bootstrap
   label: bootstrap
+- build:
+    env:
+      TEST_ENV_PIPELINE: test-pipeline
+  command:
+  - make trigger-step
+  key: trigger-step
+  label: trigger-another-pipeline
+  trigger: my-other-build-pipeline
+- build:
+    env:
+      EXISTING_ENV_VAR: persisted
+      TEST_ENV_PIPELINE: test-pipeline
+  command:
+  - make trigger-step
+  key: trigger-step
+  label: trigger-another-pipeline
+  trigger: my-other-build-pipeline
+- build:
+    env:
+      TEST_ENV_PIPELINE: test-pipeline
+    message: has existing build key
+  command:
+  - make trigger-step
+  key: trigger-step
+  label: trigger-another-pipeline
+  trigger: my-other-build-pipeline
 - command:
   - cd \$\$BUILDPIPE_PROJECT_PATH
   - make test


### PR DESCRIPTION
## Overview

This PR addresses what appears to be a regression of behaviour introduced in: #41 

Buildkite `trigger` steps don't support a top level `env` property, but the new global/project env var injection means that all steps, even trigger steps, will at least always have `env: {}`, causing them to fail:

```
`env` is not a valid property on the `trigger` step. Please check the documentation to get a full list of supported properties.
```

This PR introduces the same env vars to each step but for trigger steps, nests it under `build`, `env`:

### Input

```yaml
env:
  SOME: var

steps:
  - trigger: some-pipeline
     command:
       - make something
```

### Output

**Before**
```yaml
env:
  SOME: var

steps:
  - trigger: some-pipeline
     env:
       SOME: var
     command:
       - make something
```

**After**

```yaml
env:
  SOME: var

steps:
  - trigger: some-pipeline
     build:
       env:
         SOME: var
     command:
       - make something
```

It handles the existence / non-existence of build and its nested env property. 


## Outstanding Questions

Since `trigger` steps don't support top level `env`, presumably they also can't support:

```
env:
  BUILDPIPE_SCOPE: project 
```

Does this mean trigger steps can't be run / skipped /etc per project?
  
```