### PR TITLE
Update to 0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Example
 steps:
   - label: ":buildkite:"
     plugins:
-      - jwplayer/buildpipe#v0.9.4:
+      - jwplayer/buildpipe#v0.10.0:
           dynamic_pipeline: dynamic_pipeline.yml
 ```
 

--- a/hooks/command
+++ b/hooks/command
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-buildpipe_version="${BUILDKITE_PLUGIN_BUILDPIPE_VERSION:-0.9.4}"
+buildpipe_version="${BUILDKITE_PLUGIN_BUILDPIPE_VERSION:-0.10.0}"
 is_test="${BUILDKITE_PLUGIN_BUILDPIPE_TEST_MODE:-false}"
 
 if [[ "$is_test" == "false" ]]; then


### PR DESCRIPTION
## Overview

It appears that when features for `0.10.0` [were added](https://github.com/jwplayer/buildpipe-buildkite-plugin/pull/79/files), they weren't "released" 

i.e the `hooks/command` still refers to 0.9.4, as does the README

## This PR

* Updates hooks/command from 0.9.4 -> 0.10.0

* Updates README to refer to 0.10.0

* _Probably_ Fixes `BUILDKITE_PLUGIN_BUILDPIPE_BUILD_PROJECTS` env var not working #82

## Outstanding Questions

Is anything else required for release? Is the binary attached to the 0.10.0 release correct?