### PR TITLE
BK-19: Enforce clean checkouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+0.11.0 (rikheijdens)
+-----------------
+
+1. Buildpipe now enforces clean checkouts in order to ensure that changes are being detected properly.
+
 0.10.0 (boyntoni)
 -----------------
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Example
 steps:
   - label: ":buildkite:"
     plugins:
-      - jwplayer/buildpipe#v0.10.0:
+      - jwplayer/buildpipe#v0.11.0:
           dynamic_pipeline: dynamic_pipeline.yml
 ```
 
@@ -221,25 +221,6 @@ steps:
     env:
       BUILDKITE_PLUGIN_BUILDPIPE_DYNAMIC_PIPELINE: path/to/dynamic_pipeline.yml
       BUILDKITE_PLUGIN_BUILDPIPE_LOG_LEVEL: debug
-```
-
-Troubleshooting
----------------
-
-### Buildpipe is incorrectly showing project as changed
-
-Buildkite doesn\'t by default do clean checkouts. To enable clean
-checkouts set the `BUILDKITE_CLEAN_CHECKOUT` [environment variable](https://buildkite.com/docs/pipelines/environment-variables). An
-example is to modify the pre-checkout hook,
-`.buildkite/hooks/pre-checkout`:
-
-```bash
-#!/bin/bash
-set -euo pipefail
-
-echo '--- :house_with_garden: Setting up pre-checkout'
-
-export BUILDKITE_CLEAN_CHECKOUT="true"
 ```
 
 Testing

--- a/hooks/command
+++ b/hooks/command
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-buildpipe_version="${BUILDKITE_PLUGIN_BUILDPIPE_VERSION:-0.10.0}"
+buildpipe_version="${BUILDKITE_PLUGIN_BUILDPIPE_VERSION:-0.11.0}"
 is_test="${BUILDKITE_PLUGIN_BUILDPIPE_TEST_MODE:-false}"
 
 if [[ "$is_test" == "false" ]]; then

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+echo '--- :house_with_garden: Setting up pre-checkout'
+export BUILDKITE_CLEAN_CHECKOUT="true"

--- a/tests/post-pre-checkout.bats
+++ b/tests/post-pre-checkout.bats
@@ -1,0 +1,8 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+
+@test "Test the pre-checkout hook" {
+  run "$PWD/hooks/pre-checkout"
+  assert_success
+}


### PR DESCRIPTION
Buildpipe does not enforce Buildkite to perform clean checkouts by default, this can lead to situations where it incorrectly detects changed files.

Previously, it was recommended to set up a `pre-checkout` hook in the repository. However, this doesn't actually work. There are only two ways to make that work:
* define the `pre-checkout` hook at the agent level, or:
* define the `pre-checkout` hook at the plugin level.

This PR follows the latter approach and changes Buildpipe's behavior to enforce clean checkouts.