### PR TITLE
Bump version to 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+0.10.1 (TBoshoven)
+------------------
+
+1. Re-tag to properly pick the proper version when using the hook.
+
 0.10.0 (boyntoni)
 -----------------
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Example
 steps:
   - label: ":buildkite:"
     plugins:
-      - jwplayer/buildpipe#v0.10.0:
+      - jwplayer/buildpipe#v0.10.1:
           dynamic_pipeline: dynamic_pipeline.yml
 ```
 

--- a/hooks/command
+++ b/hooks/command
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-buildpipe_version="${BUILDKITE_PLUGIN_BUILDPIPE_VERSION:-0.10.0}"
+buildpipe_version="${BUILDKITE_PLUGIN_BUILDPIPE_VERSION:-0.10.1}"
 is_test="${BUILDKITE_PLUGIN_BUILDPIPE_TEST_MODE:-false}"
 
 if [[ "$is_test" == "false" ]]; then


### PR DESCRIPTION
The git tag for 0.10.0 is pointing at the wrong commit.
This is causing the hook to still point at the previous version.

We could fix the tag, but that doesn't necessarily propagate cleanly.
Instead, let's just use a new version number to fix this.

To do after merging: repeat the release steps (binary from 0.10.0 can be reused for 0.10.1).