### PR TITLE
Fix buildpipe not working if any attributes are used on the wait step

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -104,7 +104,7 @@ func generatePipeline(steps []interface{}, pipelineEnv map[string]string, projec
 
 		env, foundEnv := stepMap["env"].(map[interface{}]interface{})
 		_, foundBlockStep := stepMap["block"].(string)
-		_, foundWaitStep := stepMap["wait"].(string)
+		_, foundWaitStep := stepMap["wait"]
 
 		if !foundBlockStep && !foundWaitStep {
 			if !foundEnv {

--- a/pipeline.go
+++ b/pipeline.go
@@ -104,8 +104,9 @@ func generatePipeline(steps []interface{}, pipelineEnv map[string]string, projec
 
 		env, foundEnv := stepMap["env"].(map[interface{}]interface{})
 		_, foundBlockStep := stepMap["block"].(string)
+		_, foundWaitStep := stepMap["wait"].(string)
 
-		if !foundBlockStep {
+		if !foundBlockStep && !foundWaitStep {
 			if !foundEnv {
 				env = make(map[interface{}]interface{})
 				stepMap["env"] = env

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -7,7 +7,7 @@ COPY .	.
 RUN make clean
 RUN make build-linux
 
-FROM buildkite/plugin-tester
+FROM buildkite/plugin-tester:v1.1.0
 
 COPY .	.
 

--- a/tests/dynamic_pipeline.yml
+++ b/tests/dynamic_pipeline.yml
@@ -28,7 +28,7 @@ steps: # the same schema as regular buildkite pipeline steps
     command:
       - cd $$BUILDPIPE_PROJECT_PATH # BUILDPIPE_PROJECT_PATH will be set by buildpipe
       - make test
-  - wait
+  - wait: ~
   - label: build
     branches: "master"
     env:

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -51,7 +51,7 @@ steps:
     TEST_ENV_PROJECT: test-project
   key: test:project1
   label: test project1
-- wait
+- wait: null
 - agents:
   - queue=build
   branches: master


### PR DESCRIPTION
Buildkite supports attributes on the `wait` step: https://buildkite.com/docs/pipelines/wait-step, but if you try and use these with Buildpipe it will fail.

> 422 `env` is not a valid property on the `wait` step. Please check the documentation to get a full list of supported properties.

```
- env: {}
  if: build.source == "schedule" && build.branch == "master"
  wait: null
```