### PR TITLE
Allow notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+0.10.3 (oallenj)
+------------------
+
+1. Allow buildpipe to use buildkite's notification.
+
 0.10.2 (oallenj)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Example
 steps:
   - label: ":buildkite:"
     plugins:
-      - jwplayer/buildpipe#v0.10.2:
+      - jwplayer/buildpipe#v0.10.3:
           dynamic_pipeline: dynamic_pipeline.yml
 ```
 

--- a/hooks/command
+++ b/hooks/command
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-buildpipe_version="${BUILDKITE_PLUGIN_BUILDPIPE_VERSION:-0.10.2}"
+buildpipe_version="${BUILDKITE_PLUGIN_BUILDPIPE_VERSION:-0.10.3}"
 is_test="${BUILDKITE_PLUGIN_BUILDPIPE_TEST_MODE:-false}"
 
 if [[ "$is_test" == "false" ]]; then

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ type Config struct {
 	Projects []Project         `yaml:"projects"`
 	Steps    []interface{}     `yaml:"steps"`
 	Env      map[string]string `yaml:"env"`
+	Notify   []interface{}     `yaml:"notify"`
 }
 
 func NewConfig(filename string) *Config {
@@ -54,7 +55,7 @@ func projectsFromBuildProjects(buildProjects string, projects []Project) []Proje
 	for _, projectName := range projectNames {
 		for _, configProject := range projects {
 			if projectName == configProject.Label {
-				affectedProjects  = append(affectedProjects, configProject)
+				affectedProjects = append(affectedProjects, configProject)
 			}
 		}
 	}
@@ -71,7 +72,7 @@ func main() {
 	log.SetLevel(ll)
 
 	config := NewConfig(os.Getenv(pluginPrefix + "DYNAMIC_PIPELINE"))
-	buildProjects := os.Getenv(pluginPrefix+"BUILD_PROJECTS")
+	buildProjects := os.Getenv(pluginPrefix + "BUILD_PROJECTS")
 
 	var affectedProjects []Project
 	if len(buildProjects) > 0 {
@@ -90,7 +91,7 @@ func main() {
 		}
 	}
 
-	pipeline := generatePipeline(config.Steps, config.Env, affectedProjects)
+	pipeline := generatePipeline(config.Steps, config.Notify, config.Env, affectedProjects)
 
 	uploadPipeline(*pipeline)
 }

--- a/pipeline.go
+++ b/pipeline.go
@@ -11,7 +11,8 @@ import (
 )
 
 type Pipeline struct {
-	Steps []interface{} `yaml:"steps"`
+	Steps  []interface{} `yaml:"steps"`
+	Notify []interface{} `yaml:"notify,omitempty"`
 }
 
 func generateProjectSteps(steps []interface{}, step interface{}, projects []Project) []interface{} {
@@ -92,7 +93,7 @@ func findStepByKey(steps []interface{}, stepKey string) map[interface{}]interfac
 	return nil
 }
 
-func generatePipeline(steps []interface{}, pipelineEnv map[string]string, projects []Project) *Pipeline {
+func generatePipeline(steps []interface{}, notify []interface{}, pipelineEnv map[string]string, projects []Project) *Pipeline {
 	generatedSteps := make([]interface{}, 0)
 
 	for _, step := range steps {
@@ -127,7 +128,8 @@ func generatePipeline(steps []interface{}, pipelineEnv map[string]string, projec
 	}
 
 	return &Pipeline{
-		Steps: generatedSteps,
+		Steps:  generatedSteps,
+		Notify: notify,
 	}
 }
 

--- a/tests/dynamic_pipeline.yml
+++ b/tests/dynamic_pipeline.yml
@@ -73,3 +73,5 @@ steps: # the same schema as regular buildkite pipeline steps
     command:
       - cd $$BUILDPIPE_PROJECT_PATH
       - make deploy-prod
+notify:
+  - email: "example@example.com"

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -126,5 +126,7 @@ steps:
     BUILDPIPE_SCOPE: project
     TEST_ENV_PIPELINE: test-pipeline
   label: deploy-prd project2
+notify:
+- email: example@example.com
 EOM
 }


### PR DESCRIPTION
Previously any notifications add with `notify` would be ignored by Buildpipe, this PR allows you to send a notification at the end of a build.

See https://buildkite.com/docs/pipelines/notifications